### PR TITLE
Remote Syslog Port: Change the default port to 514.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 <match foo>
   type remote_syslog
   host example.com
-  port 25
+  port 514
   severity debug
   tag fluentd
 </match>

--- a/lib/fluent/plugin/out_remote_syslog.rb
+++ b/lib/fluent/plugin/out_remote_syslog.rb
@@ -14,7 +14,7 @@ module Fluent
     include Fluent::Mixin::RewriteTagName
 
     config_param :host, :string
-    config_param :port, :integer, :default => 25
+    config_param :port, :integer, :default => 514
 
     config_param :facility, :string, :default => "user"
     config_param :severity, :string, :default => "notice"


### PR DESCRIPTION
I have no clue why this plugin defaults the remote syslog port to 25, which is SMTP. So I propose to change the default to 514.
