### PR TITLE
Overwrite the some params with record

### DIFF
--- a/lib/fluent/plugin/out_remote_syslog.rb
+++ b/lib/fluent/plugin/out_remote_syslog.rb
@@ -43,8 +43,8 @@ module Fluent
         tag = rewrite_tag!(tag.dup)
         @loggers[tag] ||= RemoteSyslogLogger::UdpSender.new(@host,
           @port,
-          facility: @facility,
-          severity: @severity,
+          facility: record['facility'] || @facility,
+          severity: record['severity'] || @severity,
           program: tag,
           local_hostname: @hostname)
 

--- a/lib/fluent/plugin/out_remote_syslog.rb
+++ b/lib/fluent/plugin/out_remote_syslog.rb
@@ -43,8 +43,8 @@ module Fluent
         tag = rewrite_tag!(tag.dup)
         @loggers[tag] ||= RemoteSyslogLogger::UdpSender.new(@host,
           @port,
-          facility: record['facility'] || @facility,
-          severity: record['severity'] || @severity,
+          facility: record["facility"] || @facility,
+          severity: record["severity"] || @severity,
           program: tag,
           local_hostname: @hostname)
 


### PR DESCRIPTION
Sometimes I want to overwrite the params such as "severity"

This patch makes it possible.
If the record does not contain "severity" or "facility", it will works as usual