### PR TITLE
Remove outdated development settings in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'remote_syslog_sender', github: "reproio/remote_syslog_logger"
-
 # Specify your gem's dependencies in fluent-plugin-remote_syslog.gemspec
 gemspec


### PR DESCRIPTION
Hi, @joker1007.
Congrats to become a new maintainer. :tada:

I've found that suspicious customized dependency.
Could you take a look?

Because upstream should not depends on downstream customized gem.
It should depend on vanilla gem.

Thanks.