### PR TITLE
Allow for dynamic variables for configuration

### DIFF
--- a/lib/fluent/plugin/out_remote_syslog.rb
+++ b/lib/fluent/plugin/out_remote_syslog.rb
@@ -56,8 +56,6 @@ module Fluent
           raise ConfigError, "formatter_type must be text_per_line formatter"
         end
 
-        validate_target = "host=#{@host}/host_with_port=#{@host_with_port}/hostname=#{@hostname}/facility=#{@facility}/severity=#{@severity}/program=#{@program}"
-        placeholder_validate!(:remote_syslog, validate_target)
         @senders = []
       end
 


### PR DESCRIPTION
Remove validation of placeholders at startup to allow for dynamic variables to be used for hostname, program and others.

This allows for things like:

```
  <match logs.**>
    @type remote_syslog

    # ...

    # Take these parameters from the record
    hostname ${hostname}
    program ${program}
  </match>
```