### PR TITLE
CI: fix permission for stale action

### DIFF
--- a/.github/workflows/close-answered-issues.yml
+++ b/.github/workflows/close-answered-issues.yml
@@ -9,6 +9,8 @@ env:
 jobs:
   mark-stale-and-close-for-answered:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:


### PR DESCRIPTION
Fix a permission issue where the `stale` action failed to execute due to insufficient permissions. 

Previously, the action resulted in a `Resource not accessible by integration` error when attempting to add labels.

<img width="2032" height="199" alt="image" src="https://github.com/user-attachments/assets/b06ed928-365c-47fd-a075-8646d04c3cc3" />

https://github.com/fluent-plugins-nursery/fluent-plugin-remote_syslog/actions/runs/26448232336/job/77985568351#step:2:53